### PR TITLE
Crash_Fix

### DIFF
--- a/src/MFInAppPurchaseManager.m
+++ b/src/MFInAppPurchaseManager.m
@@ -216,5 +216,8 @@
     _hasBoughtPremium = YES;
 }
 
-
+-(void)dealloc
+{
+    [[SKPaymentQueue defaultQueue] removeTransactionObserver:self];
+}
 @end


### PR DESCRIPTION
The Library crash because 'SKPaymentQueue defaultQueue' is not deallocated properly. In the dealloc function 'removeTransactionObserver' should be called ti ensure that it doesn't crash.